### PR TITLE
Declare the const tlds in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-const tlds: string[];
+declare const tlds: string[];
 export default tlds;


### PR DESCRIPTION
The currently defined typings err with the following message:
```
Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.ts(1046)
```

What this change does is it declares the variable instead of trying to create it.