### PR TITLE
Fix index.d.ts syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-const tlds: string[];
+declare const tlds: string[];
 export default tlds;


### PR DESCRIPTION
Hello,

I recently noticed that `index.d.ts` is not compatible with recent versions of TypeScript.  You can confirm this by running the following:
```shell
$ npx tsc --noEmit index.d.ts
# index.d.ts(1,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
```
Fortunately there's a simple fix. :)

